### PR TITLE
Updating test description

### DIFF
--- a/tests/unit/emit.spec.js
+++ b/tests/unit/emit.spec.js
@@ -43,7 +43,7 @@ describe("emit", () => {
     expect(data).toEqual({ username: "alice" });
   });
 
-  it("emits an event with two arguments", () => {
+  it("emits an event containing name and password arguments", () => {
     const wrapper = shallowMount(Emitter);
 
     wrapper.vm.emitEvent();


### PR DESCRIPTION
TDC3  (Test Description and Code Conformance Checker) suggested that this description is inconsistent because it is too generic.